### PR TITLE
Save the init data specified by the user

### DIFF
--- a/floquet/floquet.py
+++ b/floquet/floquet.py
@@ -327,7 +327,7 @@ class FloquetAnalysis(Serializable):
             data_dict["floquet_modes"] = floquet_modes
         print(f"finished in {(time.time() - start_time) / 60} minutes")
         if filepath is not None:
-            self.write_to_file(filepath, data_dict)
+            self.write_to_file(filepath, data_dict | self.init_data_to_save)
         return data_dict
 
     @staticmethod


### PR DESCRIPTION
The user can specify a dictionary `init_data_to_save` when creating a `FloquetAnalysis` object. 
This commit saves that data along with the output.