### PR TITLE
Generalized bare states (defined within Model)

### DIFF
--- a/floquet/displaced_state.py
+++ b/floquet/displaced_state.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import functools
 import warnings
 
 import numpy as np
@@ -38,8 +37,7 @@ class DisplacedState:
         """Calculate overlap of floquet modes with 'bare' states.
 
         'Bare' here is defined loosely. For the first range of amplitudes, the bare
-        states are truly the bare states (the coefficients are obtained from
-        bare_state_coefficients, which give the bare states). For later ranges, we
+        states are truly the bare states (all zero coefficients). For later ranges, we
         define the bare state as the state obtained from the fit from previous range,
         with amplitude evaluated at the lower edge of amplitudes for the new region.
         This is, in a sense, the most natural choice, since it is most analogous to what
@@ -53,7 +51,8 @@ class DisplacedState:
         Parameters:
             amp_idx_0: Index specifying the lower bound of the amplitude range.
             coefficients: coefficients that specify the bare state that we calculate
-                overlaps of Floquet modes against
+                overlaps of Floquet modes against.
+                Shape: (num_states, hilbert_dim, num_fit_terms).
             floquet_modes: Floquet modes to be compared to the bare states given by
                 coefficients
         Returns:
@@ -147,54 +146,38 @@ class DisplacedState:
             )
         )
 
-    def bare_state_coefficients(self, state_idx: int) -> np.ndarray:
-        r"""For bare state only component is itself.
-
-        Parameters:
-            state_idx: Coefficients for the state $|state_idx\rangle$ that when
-                evaluated at any amplitude or frequency simply return the bare state.
-                Note that this should be the actual state index, and not the array index
-                (for instance if we have state_indices=[0, 1, 3] because we're not
-                interested in the second excited state, for the 3rd excited state we
-                should pass 3 here and not 2).
-        """
-        coefficient_matrix_for_amp_and_state = np.zeros(
-            (self.hilbert_dim, len(self.exponent_pair_idx_map)), dtype=complex
-        )
-        coefficient_matrix_for_amp_and_state[state_idx, 0] = 1.0
-        return coefficient_matrix_for_amp_and_state
-
     def displaced_state(
         self, omega_d: float, amp: float, state_idx: int, coefficients: np.ndarray
     ) -> qt.Qobj:
         """Construct the ideal displaced state based on a polynomial expansion."""
-        return sum(
+        # Compute the perturbation based on the given coefficients.
+        result = sum(
             self._coefficient_for_state(
-                np.array([omega_d, amp]),
-                *coefficients[state_idx_component, :],
-                bare_same=state_idx == state_idx_component,
+                np.array([omega_d, amp]), *coefficients[state_idx_component, :]
             )
             * qt.basis(self.hilbert_dim, state_idx_component)
             for state_idx_component in range(self.hilbert_dim)
-        ).unit()
+        )
+
+        # Add the perturbation to the bare state. Bare states are defined by the model.
+        # Get only the states corresponding to state_idx.
+        result += qt.Qobj(self.model.bare_state_array()[state_idx, :])
+
+        # Normalize and return
+        return result.unit()
 
     def _coefficient_for_state(
-        self,
-        xydata: np.ndarray,
-        *state_idx_coefficients: np.ndarray | tuple,
-        bare_same: bool = False,
+        self, xydata: np.ndarray, *state_idx_coefficients: np.ndarray | tuple
     ) -> np.ndarray | float:
         """Fit function to pass to curve fit, assume a 2D polynomial."""
         exp_pair_map = self.exponent_pair_idx_map
         omega_d, amp = xydata.T
-        result = 1.0 if bare_same else 0.0
-        result += sum(
+        return sum(
             state_idx_coefficients[idx]
             * omega_d ** exp_pair_map[idx][0]
             * amp ** exp_pair_map[idx][1]
             for idx in exp_pair_map
         )
-        return result
 
     def _create_exponent_pair_idx_map(self) -> dict:
         """Create dictionary of terms in polynomial that we fit.
@@ -260,7 +243,15 @@ class DisplacedStateFit(DisplacedState):
 
         def _fit_for_state_idx(array_state_idx: tuple[int, int]) -> np.ndarray:
             array_idx, state_idx = array_state_idx
-            floquet_mode_for_state = floquet_modes[:, :, array_idx, :]
+
+            # Get the floquet mode for the state, and subtract off the bare state
+            # i.e. only fit the perturbation.
+            state_to_fit = floquet_modes[:, :, array_idx, :]
+            state_to_fit -= np.tile(
+                self.model.bare_state_array()[None, None, state_idx, :],
+                (state_to_fit.shape[0], state_to_fit.shape[1], 1),
+            )
+
             mask = ovlp_with_bare_states[:, :, array_idx].ravel()
             # only fit states that we think haven't run into
             # a nonlinear transition (same for omega_d_amp_filtered above)
@@ -279,16 +270,15 @@ class DisplacedStateFit(DisplacedState):
                     stacklevel=3,
                 )
                 return coefficient_matrix_for_amp_and_state
+
+            # Fit each component of the state separately.
             for state_idx_component in range(self.hilbert_dim):
-                floquet_mode_bare_component = floquet_mode_for_state[
-                    :, :, state_idx_component
-                ].ravel()
-                floquet_component_filtered = floquet_mode_bare_component[
+                component = state_to_fit[:, :, state_idx_component].ravel()
+                component_filtered = component[
                     np.abs(mask) > self.options.overlap_cutoff
                 ]
-                bare_same = state_idx_component == state_idx
                 bare_component_fit = self._fit_coefficients_for_component(
-                    omega_d_amp_filtered, floquet_component_filtered, bare_same
+                    omega_d_amp_filtered, component_filtered
                 )
                 coefficient_matrix_for_amp_and_state[state_idx_component, :] = (
                     bare_component_fit
@@ -309,10 +299,7 @@ class DisplacedStateFit(DisplacedState):
         )
 
     def _fit_coefficients_for_component(
-        self,
-        omega_d_amp_filtered: list,
-        floquet_component_filtered: np.ndarray,
-        bare_same: bool,
+        self, omega_d_amp_filtered: list, floquet_component_filtered: np.ndarray
     ) -> np.ndarray:
         """Fit the floquet modes to an "ideal" displaced state based on a polynomial.
 
@@ -323,22 +310,20 @@ class DisplacedStateFit(DisplacedState):
         p0 = np.zeros(len(self.exponent_pair_idx_map))
         # fit the real and imaginary parts of the overlap separately
         popt_r = self._fit_coefficients_factory(
-            omega_d_amp_filtered, np.real(floquet_component_filtered), p0, bare_same
+            omega_d_amp_filtered, np.real(floquet_component_filtered), p0
         )
         popt_i = self._fit_coefficients_factory(
-            omega_d_amp_filtered,
-            np.imag(floquet_component_filtered),
-            p0,
-            False,  # for the imaginary part, constant term should always be zero
+            omega_d_amp_filtered, np.imag(floquet_component_filtered), p0
         )
         return popt_r + 1j * popt_i
 
     def _fit_coefficients_factory(
-        self, XYdata: list, Zdata: np.ndarray, p0: tuple | np.ndarray, bare_same: bool
+        self, XYdata: list, Zdata: np.ndarray, p0: tuple | np.ndarray
     ) -> np.ndarray:
-        poly_fit = functools.partial(self._coefficient_for_state, bare_same=bare_same)
         try:
-            popt, _ = sp.optimize.curve_fit(poly_fit, XYdata, Zdata, p0=p0)
+            popt, _ = sp.optimize.curve_fit(
+                self._coefficient_for_state, XYdata, Zdata, p0=p0
+            )
         except RuntimeError:
             warnings.warn(
                 "fit failed for a bare component, returning zeros for the fit",

--- a/floquet/floquet.py
+++ b/floquet/floquet.py
@@ -152,20 +152,6 @@ class FloquetAnalysis(Serializable):
             )
         return ovlps_and_modes
 
-    def bare_state_array(self) -> np.ndarray:
-        """Return array of bare states.
-
-        Used to specify initial bare states for the Blais branch analysis.
-        """
-        return np.squeeze(
-            np.array(
-                [
-                    qt.basis(self.hilbert_dim, idx).data.to_array()
-                    for idx in range(self.hilbert_dim)
-                ]
-            )
-        )
-
     def _step_in_amp(
         self, f_modes_energies: tuple[qt.Qobj, np.ndarray], prev_f_modes: np.ndarray
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
@@ -191,7 +177,7 @@ class FloquetAnalysis(Serializable):
         Based on Blais arXiv:2402.06615, specifically Eq. (12) but going without the
         integral over floquet modes in one period.
         """
-        bare_states = self.bare_state_array()
+        bare_states = self.model.bare_state_array()
         overlaps_sq = np.abs(np.einsum("ij,kj->ik", bare_states, f_modes_ordered)) ** 2
         # sum over bare excitations weighted by excitation number
         return np.einsum("ik,i->k", overlaps_sq, np.arange(0, self.hilbert_dim))
@@ -223,7 +209,7 @@ class FloquetAnalysis(Serializable):
         We thus use the fit from the previous range of drive amplitudes as our new bare
         state.
         """
-        print(self)
+        # print(self)
         start_time = time.time()
 
         # initialize all arrays that will contain our data
@@ -252,7 +238,8 @@ class FloquetAnalysis(Serializable):
         # coefficients, whereas for the Blais calculation, the bare modes are specified
         # as actual kets.
         prev_f_modes_arr = np.tile(
-            self.bare_state_array()[None, :, :], (len(self.model.omega_d_values), 1, 1)
+            self.model.bare_state_array()[None, :, :],
+            (len(self.model.omega_d_values), 1, 1),
         )
         displaced_state = DisplacedStateFit(
             hilbert_dim=self.hilbert_dim,
@@ -260,11 +247,12 @@ class FloquetAnalysis(Serializable):
             state_indices=self.state_indices,
             options=self.options,
         )
-        previous_coefficients = np.array(
-            [
-                displaced_state.bare_state_coefficients(state_idx)
-                for state_idx in self.state_indices
-            ]
+        previous_coefficients = np.zeros(
+            (
+                len(self.state_indices),
+                self.hilbert_dim,
+                len(displaced_state.exponent_pair_idx_map),
+            )
         )
 
         num_fit_ranges = int(np.ceil(1 / self.options.fit_range_fraction))

--- a/floquet/model.py
+++ b/floquet/model.py
@@ -82,3 +82,11 @@ class Model(Serializable):
         """Return the Hamiltonian we actually simulate."""
         omega_d, amp = omega_d_amp
         return qt.QobjEvo([self.H0, [amp * self.H1, lambda t: np.cos(omega_d * t)]])
+
+    def bare_state_array(self) -> np.ndarray:
+        """Return array of true bare states.
+
+        Used to specify initial bare states and to compute average excitation
+        number for the Blais branch analysis.
+        """
+        return np.identity(self.H0.shape[-1])

--- a/tests/test_floquet.py
+++ b/tests/test_floquet.py
@@ -148,7 +148,10 @@ def test_displaced_bare_state(setup_floquet: tuple):
     )
     for state_idx in floquet_transmon.state_indices:
         ideal_state = qt.basis(floquet_transmon.hilbert_dim, state_idx)
-        disp_coeffs_bare = displaced_state.bare_state_coefficients(state_idx)
+        disp_coeffs_bare = np.zeros(
+            (floquet_transmon.hilbert_dim, len(displaced_state.exponent_pair_idx_map))
+        )
+
         # omega_d and amp values shouldn't matter
         calc_state = displaced_state.displaced_state(
             0.0, 0.0, state_idx, disp_coeffs_bare


### PR DESCRIPTION
This PR enables support for arbitrary bare states, enabling more natural workflows for multi-mode quantum systems.

**Motivation**

Previously, bare states were required to be the standard-basis states. This may be inconvenient for multi-mode systems, as the undriven eigenstates can be entangled. While it was technically possible to run `floquet` in the undriven eigenbasis, any subsequent partial trace (e.g., to extract excitation numbers for each mode, or individual mode density matrices) required a separate change-of-basis, to switch back to the product state basis. 

**Changes**

- Bare states can now be any user-specified basis, not just the standard basis. This is allowed by a simple change: rather than fitting the full Floquet mode, the code now fits only the *difference* between the Floquet mode and the corresponding bare state. This difference is known as a "perturbation" in the code. The `bare_same` argument has been removed, as it is no longer needed under the new fitting scheme.

- The bare states are specified within the `Model`. This is a natural choice, since they are closely tied to the structure of the Hamiltonian.
